### PR TITLE
update vc option to read in csv file

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -23,6 +23,7 @@ New Features
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
+- Update vc option in preprocessor to read in csv file (:pull:`294`).
 - Update docstring (:pull:`280`).
 - Update docstrings (:pull:`277`).
 - Update file search pattern for CF preprocessing (:pull:`271`).

--- a/pyremo/preproc/core.py
+++ b/pyremo/preproc/core.py
@@ -54,7 +54,7 @@ def open_mfdataset(
 
 def get_akbkem(vc):
     """create vertical coordinate dataset"""
-    akbk = vc.to_xarray().drop("index")
+    akbk = vc.to_xarray().drop_vars("index", errors="ignore")
     # bkem = pr.tables.vc.tables['vc_27lev']
     akem = akbk.ak.swap_dims({"index": lev_i})
     bkem = akbk.bk.swap_dims({"index": lev_i})

--- a/pyremo/preproc/preprocessor.py
+++ b/pyremo/preproc/preprocessor.py
@@ -267,9 +267,10 @@ class Preprocessor:
         Domain metadata dictionary or a registered domain id. If ``None`` the
         domain is inferred from ``surflib`` with a 1-grid-cell interior crop.
     vc : str or pandas.DataFrame, optional
-        Vertical coordinate table key (looked up in ``pr.vc.tables``) or a
-        pandas DataFrame defining the vertical coordinate (columns ``ak``, ``bk``,
-        and optionally ``akh``/``bkh``). Defaults to ``"vc_49lev"``.
+        Vertical coordinate table key (looked up in ``pr.vc.tables``), a path
+        to a CSV file defining the vertical coordinate, or a pandas DataFrame
+        (columns ``ak``, ``bk``, and optionally ``akh``/``bkh``). Defaults to
+        ``"vc_49lev"``.
     outpath : str, optional
         Output path template (e.g. ``"/data/run/{date:%Y%m%d}"``). If set, it
         is used by :meth:`run` when writing forcing files.
@@ -308,7 +309,10 @@ class Preprocessor:
         if vc is None:
             vc = "vc_49lev"
         if isinstance(vc, str):
-            self.vc = pr.vc.tables[vc]
+            if os.path.isfile(vc):
+                self.vc = pd.read_csv(vc)
+            else:
+                self.vc = pr.vc.tables[vc]
         else:
             self.vc = vc
         self.expid = expid
@@ -431,6 +435,7 @@ class Preprocessor:
             ds = self.get_input_dataset(date=date, initial=initial)
             if ds is None:
                 warn(f"No input dataset available for date {date}")
+                return None
         ads = self.remap(
             ds,
             domain_info=self.domain_info,


### PR DESCRIPTION
This pull request introduces several improvements to the handling of vertical coordinate tables in the preprocessing workflow. The main changes enhance flexibility by allowing vertical coordinate definitions to be provided as CSV files, improve error handling, and update documentation for clarity.

**Vertical coordinate table handling:**
* Updated the documentation for the `vc` parameter in the `Preprocessor` class to note that it can now also accept a path to a CSV file, in addition to a table key or DataFrame.
* Modified the `Preprocessor.__init__` method to check if the provided `vc` string is a file path and, if so, load it as a CSV file; otherwise, it falls back to looking up the table key.

**Robustness and error handling:**
* In the `preprocess` method, added an early return (`return None`) if no input dataset is available for the given date, preventing further processing on missing data.

**API and compatibility improvements:**
* In `get_akbkem`, replaced the deprecated `.drop("index")` with `.drop_vars("index", errors="ignore")` for compatibility with newer versions of xarray and to avoid errors if the variable does not exist.